### PR TITLE
Add nodeSelector for Redis deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `deploymentAnnotations`            | Additional annotations for ambassador DaemonSet/Deployment                      | `{}`                              |
 | `podLabels`                        | Additional labels for ambassador pods                                           |                                   |
 | `affinity`                         | Affinity for ambassador pods                                                    | `{}`                              |
+| `nodeSelector`                     | NodeSelector for ambassador pods                                                | `{}`                              |
 | `priorityClassName`                | The name of the priorityClass for the ambassador DaemonSet/Deployment           | `""`                              |
 | `rbac.create`                      | If `true`, create and use RBAC resources                                        | `true`                            |
 | `rbac.podSecurityPolicies`         | pod security polices to bind to                                                 |                                   |
@@ -115,6 +116,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `redis.create`                     | Create a basic redis instance with default configurations                       | `true`                            |
 | `redis.annotations`                | Annotations for the redis service and deployment                                | `""`                              |
 | `redis.resources`                  | Resource requests for the redis instance                                        | `""`                              |
+| `redis.nodeSelector`               | NodeSelector for redis pods                                                     | `{}`                              |
 | `authService.create`               | Create the `AuthService` CRD for Ambassador Edge Stack                          | `true`                            |
 | `authService.optional_configurations` | Config options for the `AuthService` CRD                                     | `""`                              |
 | `rateLimit.create`                 | Create the `RateLimit` CRD for Ambassador Edge Stack                            | `true`                            |

--- a/templates/aes-redis.yaml
+++ b/templates/aes-redis.yaml
@@ -53,4 +53,8 @@ spec:
         resources:
         {{- toYaml .Values.redis.resources | nindent 10 }}
       restartPolicy: Always
+      {{- with .Values.redis.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -257,6 +257,7 @@ redis:
   #   requests:
   #     cpu: 50m
   #     memory: 128Mi
+  nodeSelector: {}
 
 authService:
   create: true


### PR DESCRIPTION
I wanted to deploy this chart on a mixed windows-linux cluster, for which I need to direct all pods to the linux nodes. The Redis deployment did not support nodeSelectors yet, so I did a quick addition and added docs for (both) nodeSelector fields 