### PR TITLE
Update default autoscaling metrics to be compatible with autoscaling v2beta2

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -22,12 +22,16 @@ autoscaling:
   metrics:
     - type: Resource
       resource:
-        name: cpu
-        targetAverageUtilization: 60
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 60
     - type: Resource
       resource:
-        name: memory
-        targetAverageUtilization: 60
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 60
 
 podDisruptionBudget: {}
 
@@ -148,11 +152,11 @@ rbac:
   create: true
   podSecurityPolicies:
     {}
-  # Name of the RBAC resources defaults to the name of the release. 
+  # Name of the RBAC resources defaults to the name of the release.
   # Set nameOverride when installing Ambassador with cluster-wide scope in
   # different namespaces with the same release name to avoid conflicts.
   nameOverride:
-  
+
 scope:
   # tells Ambassador to only use resources in the namespace or namespace set by namespace.name
   singleNamespace: false
@@ -226,7 +230,7 @@ crds:
   create: true
   keep: true
 
-# The Ambassador Edge Stack is free for limited use without a license key. 
+# The Ambassador Edge Stack is free for limited use without a license key.
 # Go to https://{ambassador-host}/edge_stack/admin/#dashboard to register
 # for a community license key.
 
@@ -240,8 +244,8 @@ licenseKey:
   secretName:
 
 
-# The Ambassador Edge Stack uses a redis instance for managing authentication, 
-# rate limiting, and sharing minor configuration details between pods for 
+# The Ambassador Edge Stack uses a redis instance for managing authentication,
+# rate limiting, and sharing minor configuration details between pods for
 # centralized management. These values configure the redis instance that ships
 # by default with The Ambassador Edge Stack.
 #


### PR DESCRIPTION
Autoscaling v2beta2 uses a new format for resource targeting.  Currently the hpa template is referencing this newer version but the defaults will fail:

```
UPGRADE FAILED: error validating "": error validating data: 
[ValidationError(HorizontalPodAutoscaler.spec.metrics[0].resource): unknown field "targetAverageUtilization" in io.k8s.api.autoscaling.v2beta2.ResourceMetricSource, ValidationError(HorizontalPodAutoscaler.spec.metrics[0].resource): missing required field "target" in io.k8s.api.autoscaling.v2beta2.ResourceMetricSource, 
ValidationError(HorizontalPodAutoscaler.spec.metrics[1].resource): unknown field "targetAverageUtilization" in io.k8s.api.autoscaling.v2beta2.ResourceMetricSource, ValidationError(HorizontalPodAutoscaler.spec.metrics[1].resource): missing required field "target" in io.k8s.api.autoscaling.v2beta2.ResourceMetricSource]
```

This is my first PR here so please let me know if I am missing anything.  Thanks again for this great chart!