### PR TITLE
Move to checking the Chart.yaml for a version bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     # - PROVIDER="kubernaut"
     - PROVIDER="k3d"
     # PUSH_CHART must be != "false" for pushing the chart
-    - PUSH_CHART="true"
+    - PUSH_CHART="false"
     - AWS_BUCKET="datawire-static-files"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,5 +37,5 @@ deploy:
   script: bash ./ci/push_chart.sh
   on:
     # FIXME: use "branch: master" for publishing only in tags in "master"
-    branch: master
+    branch: ci-test
     #all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ deploy:
   provider: script
   script: bash ./ci/push_chart.sh
   on:
-    tags: true
     # FIXME: use "branch: master" for publishing only in tags in "master"
     branch: master
     #all_branches: true

--- a/ci/push_chart.sh
+++ b/ci/push_chart.sh
@@ -10,10 +10,16 @@ source "$CURR_DIR/common.sh"
 
 #########################################################################################
 
-if [ -z "$TRAVIS_TAG" ]  ; then
-  info "No TRAVIS_TAG in environment: no Helm package will be built..."
+# Check for update to version of Chart.yaml
+
+version_changed=$(git diff $TRAVIS_COMMIT_RANGE Chart.yaml | grep +version)
+
+if [ -z $version_changed ]
+then
+  info "The version was not changed in Chart.yaml: the chart will not be pushed..."
   exit 0
 fi
+
 
 info "Pushing Helm Chart"
 helm package $TOP_DIR


### PR DESCRIPTION
I was poking at the chart today and thinking about how awful the UX of
needing to push a tag just to get the chart to build and push a new
version is.

I decided that the simplest way to decide when to build and push is to
check to see if the version of the chart was updated.

The simplest way I could think to accomplish this is by taking a diff of
the Chart.yaml file and checking to see if the `version` was edited.

Travis has an environment variable `TRAVIS_COMMIT_RANGE` for storing the
range of the pull request that triggered this build. I believe using
this variable to `git diff Chart.yaml` accomplishes what I am looking
for.

Signed-off-by: Noah Krause <krausenoah@gmail.com>