### PR TITLE
add option to create service monitor for prometheus operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v6.3.0
+
+- Adds: Option to create a ServiceMonitor for scraping via Prometheus Operator
+
 ## v6.2.5
 
 - Upgrade Ambassador to version 1.4.0: [CHANGELOG}](https://github.com/datawire/ambassador/blob/master/CHANGELOG.md)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.4.0
 ossVersion: 1.4.0
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 6.2.5
+version: 6.3.0
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `prometheusExporter.repository`    | DEPRECATED: Prometheus exporter image                                           | `prom/statsd-exporter`            |
 | `prometheusExporter.tag`           | DEPRECATED: Prometheus exporter image                                           | `v0.8.1`                          |
 | `prometheusExporter.resources`     | DEPRECATED: CPU/memory resource requests/limits                                 | `{}`                              |
+| `metrics.serviceMonitor.enabled`   | Create ServiceMonitor object (`adminService.create` should be to `true`)        | `false`                           |
+| `metrics.serviceMonitor.interval`  | Interval at which metrics should be scraped                                     | `30s`                             |
+| `metrics.serviceMonitor.scrapeTimeout` | Timeout after which the scrape is ended                                     | `30s`                             |
 
 **NOTE:** Make sure the configured `service.http.targetPort` and `service.https.targetPort` ports match your [Ambassador Module's](https://www.getambassador.io/reference/modules/#the-ambassador-module) `service_port` and `redirect_cleartext_from` configurations.
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ If you intend to use `service.annotations`, remember to include the `getambassad
 
 ### Prometheus Metrics
 
-Using the Prometheus Exporter has been deprecated and is no longer recommended.
+Using the Prometheus Exporter has been deprecated and is no longer recommended. You can now use `metrics.serviceMonitor.enabled` to create a `ServiceMonitor` from the chart if the [Prometheus Operator](https://github.com/coreos/prometheus-operator) has been installed on your cluster.
 
 Please see Ambassador's [monitoring with Prometheus](https://www.getambassador.io/user-guide/monitoring/) docs for more information on using the `/metrics` endpoint for metrics collection.
 

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.adminService.create .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "ambassador.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ include "ambassador.name" . }}
+spec:
+  endpoints:
+    - port: ambassador-admin
+      path: /metrics
+      {{- with .Values.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      service: ambassador-admin
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -335,3 +335,11 @@ prometheusExporter:
   #     timer_type: 'histogram'
   #     labels:
   #       cluster_name: "$1"
+
+# Prometheus Operator ServiceMonitor configuration
+# See documentation: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor
+metrics:
+  serviceMonitor:
+    enabled: false
+    # interval: 30s
+    # scrapeTimeout: 30s


### PR DESCRIPTION
first of all, thanks for amazing project :)

This does https://github.com/datawire/ambassador-chart/issues/14 and would be super helpful for me. Some notes:

- tried to keep it simple
- tried to be compatible with https://www.getambassador.io/user-guide/monitoring/
  - that uses the admin service. It seems to me that we could just use main ambassador service to avoid the dependency on the adminService, but I'm not sure if that's desirable or not
