### PR TITLE
Use explicit types for things like ports

### DIFF
--- a/templates/admin-service.yaml
+++ b/templates/admin-service.yaml
@@ -25,7 +25,7 @@ spec:
       protocol: TCP
       name: ambassador-admin
       {{- if (and (eq .Values.adminService.type "NodePort") (not (empty .Values.adminService.nodePort))) }}
-      nodePort: {{ .Values.adminService.nodePort }}
+      nodePort: {{ int .Values.adminService.nodePort }}
       {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -125,7 +125,7 @@ spec:
           ports:
             {{- range .Values.service.ports }}
             - name: {{ .name }}
-              containerPort: {{ .targetPort }}
+              containerPort: {{ int .targetPort }}
               {{- if .protocol }}
               protocol: {{ .protocol }}
               {{- end }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -24,7 +24,19 @@ spec:
   externalTrafficPolicy: "{{ .Values.service.externalTrafficPolicy }}"
   {{- end }}
   ports:
-    {{- toYaml .Values.service.ports | nindent 4 }}
+    {{- range .Values.service.ports }}
+    - name: {{ .name }}
+      port: {{ int .port }}
+      {{- if .targetPort }}
+      targetPort: {{ int .targetPort }}
+      {{- end }}
+      {{- if .nodePort }}
+      nodePort: {{ int .nodePort }}
+      {{- end }}
+      {{- if .protocol }}
+      protocol: {{ .protocol }}
+      {{- end }}
+    {{- end}}
   selector:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
Use explicit types for things like ports, so commands like `helm .. --set service.ports[0].port=80` is replaced as an integer and not as a string (and leading to an error).

Part of the solution for datawire/apro#1077



