### PR TITLE
Fix podSecurityPolicies type

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.3.2
 ossVersion: 1.3.2
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 6.2.3
+version: 6.2.4
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/values.yaml
+++ b/values.yaml
@@ -40,7 +40,7 @@ podDisruptionBudget: {}
 
 # Additional container environment variable
 # Uncomment or add additional environment variables for the container here.
-env:
+env: {}
   # Exposing statistics via StatsD
   # STATSD_ENABLED: true
   # STATSD_HOST: statsd-sink
@@ -90,7 +90,7 @@ service:
 
   externalTrafficPolicy:
 
-  annotations:
+  annotations: {}
   #############################################################################
   ## Ambassador should be configured using CRD definition. If you want
   ## to use annotations, the following is an example of annotating the
@@ -152,8 +152,7 @@ adminService:
 rbac:
   # Specifies whether RBAC resources should be created
   create: true
-  podSecurityPolicies:
-    {}
+  podSecurityPolicies: []
   # Name of the RBAC resources defaults to the name of the release.
   # Set nameOverride when installing Ambassador with cluster-wide scope in
   # different namespaces with the same release name to avoid conflicts.


### PR DESCRIPTION
An array is expected, but an object is defined so helm3 is complaining
with:

warning: cannot overwrite table with non table for podSecurityPolicies (map[])