### PR TITLE
Customizable managed-by, using the deploymentTool (undocumented) value

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -59,3 +59,20 @@ Define the http port of the Ambassador service
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Filter the valid deploymentTool
+*/}}
+{{- define "ambassador.managedBy" -}}
+    {{- if .Values.deploymentTool -}}
+        {{- if (eq .Values.deploymentTool "edgectl") -}}
+            edgectl
+        {{- else if (eq .Values.deploymentTool "amb-oper") -}}
+            amb-oper
+        {{- else -}}
+            {{ .Release.Service -}}
+        {{- end -}}
+    {{- else -}}
+        {{- .Release.Service -}}
+    {{- end -}}
+{{- end -}}

--- a/templates/admin-service.yaml
+++ b/templates/admin-service.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/part-of: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
     # Hard-coded label for Prometheus Operator ServiceMonitor
     service: ambassador-admin
     product: aes

--- a/templates/aes-authservice.yaml
+++ b/templates/aes-authservice.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
     app.kubernetes.io/component: {{ include "ambassador.name" . }}-auth
     product: aes
 spec:

--- a/templates/aes-internal.yaml
+++ b/templates/aes-internal.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
     app.kubernetes.io/component: {{ include "ambassador.name" . }}-devportal
     product: aes
 spec:
@@ -34,7 +34,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
     app.kubernetes.io/component: {{ include "ambassador.name" . }}-devportal-demo
     product: aes
 spec:
@@ -57,7 +57,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
     app.kubernetes.io/component: {{ include "ambassador.name" . }}-devportal-api
     product: aes
 spec:

--- a/templates/aes-ratelimit.yaml
+++ b/templates/aes-ratelimit.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
     app.kubernetes.io/component: {{ include "ambassador.name" . }}-ratelimit
     product: aes
 spec:

--- a/templates/aes-redis.yaml
+++ b/templates/aes-redis.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
   annotations:
     {{- toYaml .Values.redis.annotations.service | nindent 4}}
 spec:
@@ -32,7 +32,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
     product: aes
   annotations:
     {{- toYaml .Values.redis.annotations.deployment | nindent 4}}

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
 data:
   ambassadorConfig: |-
     {{- .Values.ambassadorConfig | nindent 4 }}

--- a/templates/crd-delete.yaml
+++ b/templates/crd-delete.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
 spec:
   template:
     metadata:
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/part-of: {{ .Release.Name }}
         helm.sh/chart: {{ include "ambassador.chart" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
     spec:
       {{- if .Values.rbac.create }}
       serviceAccountName: {{ include "ambassador.serviceAccountName" . }}

--- a/templates/crds-rbac.yaml
+++ b/templates/crds-rbac.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}    
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
     product: aes
 rules:
   - apiGroups: [ "apiextensions.k8s.io" ]
@@ -39,7 +39,7 @@ metadata:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
     product: aes
     {{- if .Values.deploymentAnnotations }}
   annotations:
@@ -38,6 +38,7 @@ spec:
         app.kubernetes.io/name: {{ include "ambassador.name" . }}
         app.kubernetes.io/part-of: {{ .Release.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
         product: aes
       {{- if .Values.podLabels }}
         {{- toYaml .Values.podLabels | nindent 8 }}

--- a/templates/exporter-config.yaml
+++ b/templates/exporter-config.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
 data:
   exporterConfiguration:
 {{- if .Values.prometheusExporter.configuration }} |

--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/templates/pdb.yaml
+++ b/templates/pdb.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
 spec:
   selector:
     matchLabels:

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
     product: aes
 rules:
   - apiGroups: [""]
@@ -86,7 +86,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
     product: aes
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
     app.kubernetes.io/component: ambassador-service
     product: aes
   {{- with .Values.service.annotations }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -9,6 +9,6 @@ metadata:
     app.kubernetes.io/part-of: {{ .Release.Name }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
     product: aes
 {{- end -}}

--- a/templates/tests/test-ready.yaml
+++ b/templates/tests/test-ready.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     helm.sh/chart: {{ include "ambassador.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/managed-by: {{ include "ambassador.managedBy" . }}
   annotations:
     "helm.sh/hook": test-success
 spec:


### PR DESCRIPTION
We can set an undocumented value `deploymentTool` from inside `edgectl install` or the Operator for describing how this Helm was installed (ie, so setting `deploymentTool=edgectl` will create resources all with the label `app.kubernetes.io/managed-by: edgectl`). When not defined, the default value (`Helm`) will be used.

We can simulate this in command line with `helm install ambassador --namespace ambassador . --set deploymentTool=edgectl` (but regular users will never do this!).

https://github.com/datawire/ambassador/pull/2492 depends on this feature for differentiating between installations performed by plain Helm and by the Operator or `edgectl install`.