### PR TITLE
RBAC Error due to bad RBAC configs

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.4.0
 ossVersion: 1.4.0
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 6.2.5
+version: 6.2.6
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.4.1
 ossVersion: 1.4.1
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 6.3.2
+version: 6.3.3
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/templates/crds-rbac.yaml
+++ b/templates/crds-rbac.yaml
@@ -29,6 +29,8 @@ rules:
     - filters.getambassador.io
     - filterpolicies.getambassador.io
     - ratelimits.getambassador.io
+    - hosts.getambassador.io
+    - logservices.getambassador.io
     verbs: ["get", "list", "watch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -18,9 +18,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources:
-    {{- if not .Values.scope.singleNamespace }}
     - namespaces
-    {{- end }}
     - services
     - secrets
     - endpoints


### PR DESCRIPTION
`CRDS-RBAC` is missing the latest CRDs added.
By default, the RBAC need namespace permission else gives below error in the case of `scope enabled installation`.

> 2020-04-13 11:02:27 kubewatch [12 TMainThread] 1.4.0 DEBUG: looking up ID for namespace alpha2
2020-04-13 11:02:27 kubewatch [12 TMainThread] 1.4.0 ERROR: couldn't read namespace alpha2? (403)
Reason: Forbidden
HTTP response headers: HTTPHeaderDict({'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff', 'Date': 'Mon, 13 Apr 2020 11:02:27 GMT', 'Content-Length': '334'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"namespaces \"alpha2\" is forbidden: User \"system:serviceaccount:alpha2:ambassador-alpha2\" cannot get resource \"namespaces\" in API group \"\" in the namespace \"alpha2\"","reason":"Forbidden","details":{"name":"alpha2","kind":"namespaces"},"code":403}