### PR TITLE
[WIP] Enables STATSD_HOST to be set to hostIP

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -172,6 +172,14 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
               {{- end -}}
+            {{- if .Values.sendStatsdToHostIP}}
+            - name: STATSD_ENABLED
+              value: "true"
+            - name: STATSD_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            {{- end }}
             {{- if .Values.env }}
             {{- range $key,$value := .Values.env }}
             - name: {{ $key | upper | quote}}


### PR DESCRIPTION
Couldn't figure out a way, using the helm chart as-is, to set STATSD_HOST to the lookup for hostIP. So, adding a specific helm chart value for that.