### PR TITLE
Sets env var for custom secret

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -154,6 +154,10 @@ spec:
               value: {{ include "ambassador.fullname" . }}-redis:6379
               {{- end }}
             {{- end }}
+            {{- if and .Values.licenseKey.secretName .Values.enableAES}}
+            - name: AMBASSADOR_AES_SECRET_NAME
+              value: {{ .Values.licenseKey.secretName }}
+            {{- end }}
             {{- if .Values.prometheusExporter.enabled }}
             - name: STATSD_ENABLED
               value: "true"


### PR DESCRIPTION
An environment variable needs to be set for the custom secret name to be
read. This resolves a bug where the licenseKey.secretName, while
properly mounted, would not be used as the license key secret which
default to ambassador-edge-stack

Signed-off-by: Noah Krause <krausenoah@gmail.com>
