### PR TITLE
Label for prometheus ServiceMonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
-## v6.3.1
+## v6.3.3
 
 - Add extra labels to ServiceMonitor: [CHANGELOG}](https://github.com/datawire/ambassador/blob/master/CHANGELOG.md)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v6.3.1
+
+- Add extra labels to ServiceMonitor: [CHANGELOG}](https://github.com/datawire/ambassador/blob/master/CHANGELOG.md)
+
 ## v6.3.2
 
 - Upgrade Ambassador to version 1.4.2: [CHANGELOG}](https://github.com/datawire/ambassador/blob/master/CHANGELOG.md)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.4.2
 ossVersion: 1.4.2
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 6.3.2
+version: 6.3.3
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `metrics.serviceMonitor.enabled`   | Create ServiceMonitor object (`adminService.create` should be to `true`)        | `false`                           |
 | `metrics.serviceMonitor.interval`  | Interval at which metrics should be scraped                                     | `30s`                             |
 | `metrics.serviceMonitor.scrapeTimeout` | Timeout after which the scrape is ended                                     | `30s`                             |
+| `metrics.serviceMonitor.selector`  | Label Selector for Prometheus to find ServiceMonitors                           | `{ prometheus: kube-prometheus }` |
 
 **NOTE:** Make sure the configured `service.http.targetPort` and `service.https.targetPort` ports match your [Ambassador Module's](https://www.getambassador.io/reference/modules/#the-ambassador-module) `service_port` and `redirect_cleartext_from` configurations.
 

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "ambassador.name" . }}
+    {{- if .Values.metrics.serviceMonitor.selector }}
+    {{ toYaml .Values.metrics.serviceMonitor.selector | indent 4 }}
+    {{- end }}
 spec:
   endpoints:
     - port: ambassador-admin

--- a/values.yaml
+++ b/values.yaml
@@ -343,3 +343,4 @@ metrics:
     enabled: false
     # interval: 30s
     # scrapeTimeout: 30s
+    # selector: {}


### PR DESCRIPTION
 Label Selector for Prometheus to find ServiceMonitors.

Because?
Some installations need a custom selector to search for ServiceMonitor.

Example: 
My prometheus need label "release: prometheus" for work.