### PR TITLE
Adjusting service-preview traffic component RBAC settings

### DIFF
--- a/templates/aes-authservice.yaml
+++ b/templates/aes-authservice.yaml
@@ -4,6 +4,7 @@ apiVersion: getambassador.io/v2
 kind: AuthService
 metadata:
   name: {{ include "ambassador.fullname" . }}-auth
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/templates/aes-injector.yaml
+++ b/templates/aes-injector.yaml
@@ -40,12 +40,10 @@ spec:
           value: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         - name: TRAFFIC_AGENT_AGENT_LISTEN_PORT
           value: "{{ .Values.servicePreview.trafficAgent.port }}"
+        {{- if .Values.scope.singleNamespace }}
         - name: TRAFFIC_AGENT_SERVICE_ACCOUNT_NAME
-          {{- if .Values.scope.singleNamespace }}
           value: "{{ .Values.servicePreview.trafficAgent.serviceAccountName }}"
-          {{- else }}
-          value: default
-          {{- end }}
+        {{- end }}
         ports:
         - containerPort: 8443
           name: https

--- a/templates/aes-ratelimit.yaml
+++ b/templates/aes-ratelimit.yaml
@@ -4,6 +4,7 @@ apiVersion: getambassador.io/v2
 kind: RateLimitService
 metadata:
   name: {{ include "ambassador.fullname" . }}-ratelimit
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/templates/crds-rbac.yaml
+++ b/templates/crds-rbac.yaml
@@ -33,6 +33,8 @@ rules:
     - filters.getambassador.io
     - filterpolicies.getambassador.io
     - ratelimits.getambassador.io
+    - hosts.getambassador.io
+    - logservices.getambassador.io
     verbs: ["get", "list", "watch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -22,9 +22,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources:
-    {{- if not .Values.scope.singleNamespace }}
     - namespaces
-    {{- end }}
     - services
     - secrets
     - endpoints

--- a/templates/traffic-agent-rbac.yaml
+++ b/templates/traffic-agent-rbac.yaml
@@ -18,6 +18,8 @@ metadata:
     {{- end }}
     product: aes
 ---
+## Create a service-account-token for traffic-agent with a matching name.
+## Since the ambassador-injector will use this token name, it must be deterministic and not auto-generated.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -75,32 +77,6 @@ subjects:
   - name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
     namespace: {{ .Release.Namespace }}
     kind: ServiceAccount
-{{- if and .Values.crds.enabled .Values.rbac.create }}
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}-crds
-  labels:
-    app.kubernetes.io/name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}-crds
-    app.kubernetes.io/part-of: {{ .Release.Name }}
-    helm.sh/chart: {{ include "ambassador.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    {{- if .Values.deploymentTool }}
-    app.kubernetes.io/managed-by: {{ .Values.deploymentTool }}
-    {{- else }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- end }}
-    product: aes
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ include "ambassador.rbacName" . }}-crds
-subjects:
-  - name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
-    namespace: {{ .Release.Namespace }}
-    kind: ServiceAccount
-{{- end }}
 {{- else }}
 ## If we install Service Preview cluster-wide, this means we can't use the 'traffic-agent' ServiceAccount
 ## as it does not exist in every namespace. We must instead grant new Roles to all ServiceAccounts (cluster-wide).
@@ -152,31 +128,5 @@ subjects:
   - name: system:serviceaccounts
     kind: Group
     apiGroup: rbac.authorization.k8s.io
-{{- if and .Values.crds.enabled .Values.rbac.create }}
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}-crds
-  labels:
-    app.kubernetes.io/name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}-crds
-    app.kubernetes.io/part-of: {{ .Release.Name }}
-    helm.sh/chart: {{ include "ambassador.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    {{- if .Values.deploymentTool }}
-    app.kubernetes.io/managed-by: {{ .Values.deploymentTool }}
-    {{- else }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- end }}
-    product: aes
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ include "ambassador.rbacName" . }}-crds
-subjects:
-  - name: system:serviceaccounts
-    kind: Group
-    apiGroup: rbac.authorization.k8s.io
-{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/traffic-agent-rbac.yaml
+++ b/templates/traffic-agent-rbac.yaml
@@ -6,6 +6,9 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    # Required because Helm creates secrets before ServiceAccount, but service-account-token depends on an existing SA.
+    "helm.sh/hook": "pre-install"
   labels:
     app.kubernetes.io/name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/templates/traffic-agent.yaml
+++ b/templates/traffic-agent.yaml
@@ -28,6 +28,30 @@ metadata:
 type: kubernetes.io/service-account-token
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.deploymentTool }}
+    app.kubernetes.io/managed-by: {{ .Values.deploymentTool }}
+    {{- else }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
+    product: aes
+rules:
+  - apiGroups: [""]
+    resources: [ "namespaces", "services", "secrets" ]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [ "getambassador.io" ]
+    resources: [ "*" ]
+    verbs: ["get", "list", "watch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
@@ -51,11 +75,59 @@ subjects:
   - name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
     namespace: {{ .Release.Namespace }}
     kind: ServiceAccount
+{{- if and .Values.crds.enabled .Values.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}-crds
+  labels:
+    app.kubernetes.io/name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}-crds
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.deploymentTool }}
+    app.kubernetes.io/managed-by: {{ .Values.deploymentTool }}
+    {{- else }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
+    product: aes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "ambassador.rbacName" . }}-crds
+subjects:
+  - name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
+    namespace: {{ .Release.Namespace }}
+    kind: ServiceAccount
+{{- end }}
 {{- else }}
-## TODO: If we install Service Preview cluster-wide, this means we can't use the 'traffic-agent' ServiceAccount
+## If we install Service Preview cluster-wide, this means we can't use the 'traffic-agent' ServiceAccount
 ## as it does not exist in every namespace. We must instead grant new Roles to all ServiceAccounts (cluster-wide).
-## We must revisit this ClusterRole (possibly even create a new one), with the very minimal set of permissions required.
-## Even better if it can be read-only.
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.deploymentTool }}
+    app.kubernetes.io/managed-by: {{ .Values.deploymentTool }}
+    {{- else }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
+    product: aes
+rules:
+  - apiGroups: [""]
+    resources: [ "namespaces", "services", "secrets" ]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [ "getambassador.io" ]
+    resources: [ "*" ]
+    verbs: ["get", "list", "watch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -75,10 +147,36 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "ambassador.rbacName" . }}
+  name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
 subjects:
   - name: system:serviceaccounts
     kind: Group
     apiGroup: rbac.authorization.k8s.io
+{{- if and .Values.crds.enabled .Values.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}-crds
+  labels:
+    app.kubernetes.io/name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}-crds
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.deploymentTool }}
+    app.kubernetes.io/managed-by: {{ .Values.deploymentTool }}
+    {{- else }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
+    product: aes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "ambassador.rbacName" . }}-crds
+subjects:
+  - name: system:serviceaccounts
+    kind: Group
+    apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/traffic-agent.yaml
+++ b/templates/traffic-agent.yaml
@@ -18,6 +18,15 @@ metadata:
     {{- end }}
     product: aes
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/service-account.name: traffic-agent
+type: kubernetes.io/service-account-token
+---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:

--- a/templates/traffic-manager.yaml
+++ b/templates/traffic-manager.yaml
@@ -87,6 +87,7 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
+  clusterIP: None
   selector:
     app.kubernetes.io/name: telepresence-proxy
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/templates/traffic-manager.yaml
+++ b/templates/traffic-manager.yaml
@@ -16,10 +16,13 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- end }}
     product: aes
-{{- if .Values.scope.singleNamespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- if .Values.scope.singleNamespace }}
 kind: Role
+{{- else }}
+kind: ClusterRole
+{{- end }}
 metadata:
   name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
   namespace: {{ .Release.Namespace }}
@@ -40,52 +43,11 @@ rules:
     verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- if .Values.scope.singleNamespace }}
 kind: RoleBinding
-metadata:
-  name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
-  labels:
-    app.kubernetes.io/name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
-    app.kubernetes.io/part-of: {{ .Release.Name }}
-    helm.sh/chart: {{ include "ambassador.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    {{- if .Values.deploymentTool }}
-    app.kubernetes.io/managed-by: {{ .Values.deploymentTool }}
-    {{- else }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- end }}
-    product: aes
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
-    namespace: {{ .Release.Namespace }}
 {{- else }}
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
-  labels:
-    app.kubernetes.io/name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
-    app.kubernetes.io/part-of: {{ .Release.Name }}
-    helm.sh/chart: {{ include "ambassador.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    {{- if .Values.deploymentTool }}
-    app.kubernetes.io/managed-by: {{ .Values.deploymentTool }}
-    {{- else }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    {{- end }}
-    product: aes
-rules:
-  - apiGroups: [""]
-    resources: ["services", "pods", "secrets"]
-    verbs: ["get", "list", "watch"]
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
+{{- end }}
 metadata:
   name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
   labels:
@@ -101,13 +63,16 @@ metadata:
     product: aes
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.scope.singleNamespace }}
+  kind: Role
+  {{- else }}
   kind: ClusterRole
+  {{- end }}
   name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
     namespace: {{ .Release.Namespace }}
-{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/templates/traffic-manager.yaml
+++ b/templates/traffic-manager.yaml
@@ -39,7 +39,7 @@ metadata:
     product: aes
 rules:
   - apiGroups: [""]
-    resources: ["services", "pods", "secrets"]
+    resources: ["namespaces", "services", "pods", "secrets"]
     verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/templates/traffic-manager.yaml
+++ b/templates/traffic-manager.yaml
@@ -50,6 +50,7 @@ kind: ClusterRoleBinding
 {{- end }}
 metadata:
   name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/templates/traffic-manager.yaml
+++ b/templates/traffic-manager.yaml
@@ -16,6 +16,53 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     {{- end }}
     product: aes
+{{- if .Values.scope.singleNamespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.deploymentTool }}
+    app.kubernetes.io/managed-by: {{ .Values.deploymentTool }}
+    {{- else }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
+    product: aes
+rules:
+  - apiGroups: [""]
+    resources: ["services", "pods", "secrets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.deploymentTool }}
+    app.kubernetes.io/managed-by: {{ .Values.deploymentTool }}
+    {{- else }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
+    product: aes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
+    namespace: {{ .Release.Namespace }}
+{{- else }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -60,6 +107,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
     namespace: {{ .Release.Namespace }}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -97,7 +145,7 @@ spec:
         env:
         {{- if .Values.scope.singleNamespace }}
         - name: AMBASSADOR_SINGLE_NAMESPACE
-          value: "YES"
+          value: "true"
         {{- end }}
         - name: AMBASSADOR_NAMESPACE
           {{- if .Values.namespace }}

--- a/templates/traffic-manager.yaml
+++ b/templates/traffic-manager.yaml
@@ -1,5 +1,66 @@
 {{- if and .Values.enableAES .Values.servicePreview.enabled }}
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.deploymentTool }}
+    app.kubernetes.io/managed-by: {{ .Values.deploymentTool }}
+    {{- else }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
+    product: aes
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.deploymentTool }}
+    app.kubernetes.io/managed-by: {{ .Values.deploymentTool }}
+    {{- else }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
+    product: aes
+rules:
+  - apiGroups: [""]
+    resources: ["services", "pods", "secrets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
+  labels:
+    app.kubernetes.io/name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.deploymentTool }}
+    app.kubernetes.io/managed-by: {{ .Values.deploymentTool }}
+    {{- else }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
+    product: aes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
+    namespace: {{ .Release.Namespace }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -69,6 +130,7 @@ spec:
               fieldPath: metadata.labels
             path: labels
         name: pod-info
+      serviceAccountName: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
 ---
 apiVersion: v1
 kind: Service

--- a/values.yaml
+++ b/values.yaml
@@ -348,6 +348,8 @@ metrics:
 # Setting servicePreview.enabled: true will install the Traffic Agent, Traffic Manager, and ambassador-injector
 servicePreview:
   enabled: false
+  trafficManager:
+    serviceAccountName: "traffic-manager"
   trafficAgent:
     serviceAccountName: "traffic-agent"
     port: 9900


### PR DESCRIPTION
- AuthService is installed in the same namespace as Ambassador
- RateLimitService is installed in the same namespace as Ambassador
- `TRAFFIC_AGENT_SERVICE_ACCOUNT_NAME` is only set if single namespace
- `rbac` and `crds-rbac` added missing resources used in single namespace
- `traffic-agent` RBAC using ClusterRole or Role if in single namespace
- `traffic-agent` SA uses deterministic secret token name
- `telepresence-proxy` service has `clusterIP: None`
- `telepresence-proxy` RBAC using scoped-down ClusterRole or Role if in single namespace