### PR TITLE
Revive helm/charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,76 +3,80 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
-## v6.3.4
+## v6.3.5
+ 
+- Revived the chart at [helm/charts](https://github.com/helm/charts/tree/master/stable/ambassador)
+
+## v6.3.4 (Only available at [datawire/ambassador-chart](https://github.com/datawire/ambassador-chart))
 
 - Minor bug fixes
 
-## v6.3.3
+## v6.3.3 (Only available at [datawire/ambassador-chart](https://github.com/datawire/ambassador-chart))      
 
 - Add extra labels to ServiceMonitor: [CHANGELOG}](https://github.com/datawire/ambassador/blob/master/CHANGELOG.md)
 
-## v6.3.2
+## v6.3.2 (Only available at [datawire/ambassador-chart](https://github.com/datawire/ambassador-chart))
 
 - Upgrade Ambassador to version 1.4.2: [CHANGELOG}](https://github.com/datawire/ambassador/blob/master/CHANGELOG.md)
 
-## v6.3.1
+## v6.3.1 (Only available at [datawire/ambassador-chart](https://github.com/datawire/ambassador-chart))
 
 - Upgrade Ambassador to version 1.4.1: [CHANGELOG}](https://github.com/datawire/ambassador/blob/master/CHANGELOG.md)
 
-## v6.3.0
+## v6.3.0 (Only available at [datawire/ambassador-chart](https://github.com/datawire/ambassador-chart))
 
 - Adds: Option to create a ServiceMonitor for scraping via Prometheus Operator
 
-## v6.2.5
+## v6.2.5 (Only available at [datawire/ambassador-chart](https://github.com/datawire/ambassador-chart))
 
 - Upgrade Ambassador to version 1.4.0: [CHANGELOG}](https://github.com/datawire/ambassador/blob/master/CHANGELOG.md)
 
-## v6.2.4
+## v6.2.4 (Only available at [datawire/ambassador-chart](https://github.com/datawire/ambassador-chart))
 
 - Fix typing so that Helm3 doesn't complain (thanks, [Fabrice Rabaute](https://github.com/jfrabaute)!)
 
-## v6.2.3
+## v6.2.3 (Only available at [datawire/ambassador-chart](https://github.com/datawire/ambassador-chart))
 
 - Upgrade Ambassador to version 1.3.2.
 - Use explicit types for things like ports, so that things like `helm .. --set service.ports[0].port=80` will be integers instead of ending up as strings
 
-## v6.2.2
+## v6.2.2 (Only available at [datawire/ambassador-chart](https://github.com/datawire/ambassador-chart))
 
 - Upgrade Ambassador to version 1.3.1.
 - Remove unnecessary `version` field from CRDs.
 - Add static label to AES resources, to better support `edgectl install`
 
-## v6.2.1
+## v6.2.1 (Only available at [datawire/ambassador-chart](https://github.com/datawire/ambassador-chart))
 
 - Upgrade Ambassador to version 1.3.0.
 
-## v6.2.0
+## v6.2.0 (Only available at [datawire/ambassador-chart](https://github.com/datawire/ambassador-chart))
 
 - Add option to not create DevPortal routes
 
-## v6.1.5
+## v6.1.5 (Only available at [datawire/ambassador-chart](https://github.com/datawire/ambassador-chart))
 
 - Upgrade Ambassador to version 1.2.2.
 
-## v6.1.4
+## v6.1.4 (Only available at [datawire/ambassador-chart](https://github.com/datawire/ambassador-chart))
 
 - Upgrade from Ambassador 1.2.0 to 1.2.1.
 
-## v6.1.3
+## v6.1.3 (Only available at [datawire/ambassador-chart](https://github.com/datawire/ambassador-chart))
 
 - Upgrade from Ambassador 1.1.1 to 1.2.0.
 
-## v6.1.2
+## v6.1.2 (Only available at [datawire/ambassador-chart](https://github.com/datawire/ambassador-chart))
 
 - Upgrade from Ambassador 1.1.0 to 1.1.1.
 
-## v6.1.1
+## v6.1.1 (Only available at [datawire/ambassador-chart](https://github.com/datawire/ambassador-chart))
 
 Minor Improvements:
 
 - Adds: Option to override the name of the RBAC resources
 
-## v6.1.0
+## v6.1.0 (Only available at [datawire/ambassador-chart](https://github.com/datawire/ambassador-chart))
 
 Minor improvements including:
 
@@ -81,7 +85,7 @@ Minor improvements including:
 - Fixes: Assumption that the AES will be installed only from the `datawire/aes` repository. The `enableAES` flag now configures whether the AES is installed.
 - Clarification on how to install OSS
 
-## v6.0.0
+## v6.0.0 (Only available at [datawire/ambassador-chart](https://github.com/datawire/ambassador-chart))
 
 Introduces Ambassador Edge Stack being installed by default.
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.4.2
 ossVersion: 1.4.2
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 6.3.4
+version: 6.3.5
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/ci/generate-readme-for-helm-charts.sh
+++ b/ci/generate-readme-for-helm-charts.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+CURR_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+[ -d "$CURR_DIR" ] || { echo "FATAL: no current dir (maybe running in zsh?)";  exit 1; }
+TOP_DIR=$CURR_DIR/..
+
+# shellcheck source=common.sh
+source "$CURR_DIR/common.sh"
+
+#########################################################################################################
+
+# This script does some processing to make the clone of 
+# datawire/ambassador-chart to helm/charts easy.
+
+# The only file that is different is the README that has some small changes
+
+# Trim the top 11 lines of the README
+sed 1,11d $TOP_DIR/README.md > README.md.tmp
+
+# Append the changed beginning of the file 
+
+echo '# Ambassador
+
+###### Notice:
+
+The [helm/charts](https://github.com/helm/charts) repository has been [deprecated and will be obsolete on Nov 13 2020](https://github.com/helm/charts#status-of-the-project).
+
+This chart has been provided as a convience for Ambassador users until that time.
+
+Please see https://github.com/datawire/charts for the official chart.
+
+---
+
+The Ambassador Edge Stack is a self-service, comprehensive edge stack that is Kubernetes-native and built on [Envoy Proxy](https://www.envoyproxy.io/).
+
+## TL;DR;
+
+```console
+$ helm repo add stable https://kubernetes-charts.storage.googleapis.com
+$ helm install ambassador stable/ambassador
+```
+' > README-charts.md
+
+# Append the rest of the README
+
+cat README.md.tmp >> README-for-helm-charts.md
+
+# Cleanup
+
+rm README.md.tmp
+

--- a/values.yaml
+++ b/values.yaml
@@ -244,7 +244,7 @@ licenseKey:
   createSecret: true
   secretName:
 
-# The DevPortal is exposed at /docs/ endpoint in the AES container. 
+# The DevPortal is exposed at /docs/ endpoint in the AES container.
 # Setting this to true will automatically create routes for the DevPortal.
 createDevPortalMappings: true
 
@@ -281,7 +281,7 @@ redis:
 # Setting authService.create: false will not install the AES AuthService and
 # allow you to define your own.
 #
-# Typically when using the AES, you will want to keep this set to true and use 
+# Typically when using the AES, you will want to keep this set to true and use
 # the External Filter to communicate with a custom authentication service.
 # https://www.getambassador.io/reference/filter-reference/#filter-type-external
 authService:
@@ -301,7 +301,7 @@ authService:
     # timeout_ms: 30000
 
 
-# Configures the RateLimitService in the Ambassador Edge Stack. 
+# Configures the RateLimitService in the Ambassador Edge Stack.
 # Keep this enabled to configure RateLimits in AES.
 rateLimit:
   create: true
@@ -344,3 +344,4 @@ metrics:
     # interval: 30s
     # scrapeTimeout: 30s
     # selector: {}
+

--- a/values.yaml
+++ b/values.yaml
@@ -344,4 +344,3 @@ metrics:
     # interval: 30s
     # scrapeTimeout: 30s
     # selector: {}
-


### PR DESCRIPTION
We are reviving the chart in [helm/charts](https://github.com/helm/charts/tree/master/stable/ambassador). Since we cannot go through and copy all of the previous versions of this chart into helm/charts we need to mark which versions of the chart are not available there. Marking it here as well makes the process of copying to the helm/charts repo simpler.

Signed-off-by: Noah Krause <krausenoah@gmail.com>