### PR TITLE
Support for hostPort in Deployments.

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -138,6 +138,9 @@ spec:
               {{- if .protocol }}
               protocol: {{ .protocol }}
               {{- end }}
+              {{- if .hostPort }}
+              hostPort: {{ .hostPort }}
+              {{- end }}
             {{- end}}
             - name: admin
               containerPort: 8877

--- a/values.yaml
+++ b/values.yaml
@@ -77,11 +77,13 @@ service:
       targetPort: 8080
       # protocol: TCP
       # nodePort: 30080
+      # hostPort: 80
     - name: https
       port: 443
       targetPort: 8443
       # protocol: TCP
       # nodePort: 30443
+      # hostPort: 443
     # TCPMapping_Port
       # port: 2222
       # targetPort: 2222


### PR DESCRIPTION
Support for `hostPort` in `Deployments`, necessary for making things easier in environments like [KIND](https://kind.sigs.k8s.io) where only one replica will be available in the only control-plane node, and we want that replica to just bind to port 80 and 443 in the host.

