### PR TITLE
Adding option to define environment variables in raw yaml format

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.4.3
 ossVersion: 1.4.3
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 6.3.6
+version: 6.3.7
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `hostNetwork`                      | If `true`, uses the host network, useful for on-premise setups                  | `false`                           |
 | `dnsPolicy`                        | Dns policy, when hostNetwork set to ClusterFirstWithHostNet                     | `ClusterFirst`                    |
 | `env`                              | Any additional environment variables for ambassador pods                        | `{}`                              |
+| `envRaw`                           | Any additional environment variables for ambassador pods in raw yaml format     | `{}`                              |
 | `image.pullPolicy`                 | Ambassador image pull policy                                                    | `IfNotPresent`                    |
 | `image.repository`                 | Ambassador image                                                                | `docker.io/datawire/aes`          |
 | `image.tag`                        | Ambassador image tag                                                            | `1.4.3`                           |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -185,6 +185,11 @@ spec:
               value: {{ $value | quote}}
             {{- end }}
             {{- end }}
+            {{- if .Values.envRaw }}
+            {{- with .Values.envRaw }}
+                {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /ambassador/v0/check_alive

--- a/values.yaml
+++ b/values.yaml
@@ -53,6 +53,14 @@ env: {}
   # labels Ambassador with an ID to allow for configuring multiple Ambassadors in a cluster
   # AMBASSADOR_ID: default
 
+# Additional container environment variable in raw YAML format
+# Uncomment or add additional environment variables for the container here.
+envRaw: {}
+  # - name: POD_IP
+  #   valueFrom:
+  #     fieldRef:
+  #       fieldPath: status.podIP
+
 imagePullSecrets: []
 
 securityContext:


### PR DESCRIPTION
Make it possible to define environment variables in the YAML format

For example:
```
- name: STATSD_HOST
  valueFrom:
    fieldRef:    
      fieldPath: status.hostIP
```