### PR TITLE
Support Service external IPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `service.loadBalancerIP`           | IP address to assign (if cloud provider supports it)                            | `""`                              |
 | `service.loadBalancerSourceRanges` | Passed to cloud provider load balancer if created (e.g: AWS ELB)                | None                              |
 | `service.type`                     | Service type to be used                                                         | `LoadBalancer`                    |
+| `service.externalIPs`              | External IPs to route to the ambassador service                                 | `[]`                              |
 | `serviceAccount.create`            | If `true`, create a new service account                                         | `true`                            |
 | `serviceAccount.name`              | Service account to be used                                                      | `ambassador`                      |
 | `volumeMounts`                     | Volume mounts for the ambassador service                                        | `[]`                              |

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -48,3 +48,7 @@ spec:
   loadBalancerSourceRanges:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.service.externalIPs }}
+  externalIPs:
+    {{- toYaml .Values.service.externalIPs | nindent 4 }}
+  {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -92,6 +92,8 @@ service:
 
   externalTrafficPolicy:
 
+  externalIPs: []
+
   annotations: {}
   #############################################################################
   ## Ambassador should be configured using CRD definition. If you want


### PR DESCRIPTION
Support setting external IPs for the ambassador service.

This provides additional options for routing traffic to the ambassador service, particularly for on-prem deployments that cannot make use of the LoadBalancer Service type.