### PR TITLE
The PodSecurityPolicy should not be created by def

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v6.4.1
+
+- BugFix: The `PodSecurityPolicy` should not be created by default since it is a cluster-wide resource that should only be created once. 
+
+If you would like to use the default `PodSecurityPolicy`, make sure to unset `security.podSecurityPolicy` it in all other releases.
+
 ## v6.4.0
 
 - Upgrade Ambassador to version 1.5.0: [CHANGELOG}](https://github.com/datawire/ambassador/blob/master/CHANGELOG.md)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.5.0
 ossVersion: 1.5.0
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 6.4.0
+version: 6.4.1
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/README.md
+++ b/README.md
@@ -204,7 +204,9 @@ Ambassador takes security very seriously. For this reason, the YAML installation
 
 The `security` field of the `values.yaml` file configures these default policies and replaces the `securityContext` field used earlier.
 
-The defaults will configure the pod to run as a non-root user and prohibit privilege escalation and deploy a `PodSecurityPolicy` to ensure these conditions are met.
+The defaults will configure the pod to run as a non-root user and prohibit privilege escalation and outline a `PodSecurityPolicy` to ensure these conditions are met.
+
+
 
 ```yaml
 security:
@@ -218,29 +220,34 @@ security:
     allowPrivilegeEscalation: false
   # A basic PodSecurityPolicy to ensure Ambassador is running with appropriate security permissions
   # https://kubernetes.io/docs/concepts/policy/pod-security-policy/
-  podSecurityPolicy:
-    # Add AppArmor and Seccomp annotations
-    # https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
-    annotations:
-    spec:
-      seLinux:
-        rule: RunAsAny
-      supplementalGroups:
-        rule: 'MustRunAs'
-        ranges:
-          # Forbid adding the root group.
-          - min: 1
-            max: 65535
-      fsGroup:
-        rule: 'MustRunAs'
-        ranges:
-          # Forbid adding the root group.
-          - min: 1
-            max: 65535
-      privileged: false
-      allowPrivilegeEscalation: false
-      runAsUser:
-        rule: MustRunAsNonRoot
+  #
+  # A set of reasonable defaults is outlined below. This is not created by default as it should only
+  # be created by a one Release. If you want to use the PodSecurityPolicy in the chart, create it in
+  # the "master" Release and then leave it unset in all others. Set the `rbac.podSecurityPolicies` 
+  # in all non-"master" Releases.
+  podSecurityPolicy: []
+    # # Add AppArmor and Seccomp annotations
+    # # https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
+    # annotations:
+    # spec:
+    #   seLinux:
+    #     rule: RunAsAny
+    #   supplementalGroups:
+    #     rule: 'MustRunAs'
+    #     ranges:
+    #       # Forbid adding the root group.
+    #       - min: 1
+    #         max: 65535
+    #   fsGroup:
+    #     rule: 'MustRunAs'
+    #     ranges:
+    #       # Forbid adding the root group.
+    #       - min: 1
+    #         max: 65535
+    #   privileged: false
+    #   allowPrivilegeEscalation: false
+    #   runAsUser:
+    #     rule: MustRunAsNonRoot
 ```
 
 ### Annotations

--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `replicaCount`                     | Number of Ambassador replicas                                                   | `3`                               |
 | `resources`                        | CPU/memory resource requests/limits                                             | `{ "limits":{"cpu":"1000m","memory":"600Mi"},"requests":{"cpu":"200m","memory":"300Mi"}}` |
 | `securityContext`                  | Set security context for pod                                                    | `{ "runAsUser": "8888" }`         |
-| `security.podSecurityContext`      | Set the security context for the Ambassador pod                                 | `{ "runAsNonRoot": true }`        |
-| `security.containerSecurityContext`| Set the security context for the Ambassador container                           | `{ "readOnlyRootFilesystem": true, "allowPrivilegeEscalation": false }` |
-| `security.podSecurityPolicy`       | Create a PodSecurityPolicy to be used for the pod.                              | See the CHANGELOG                 |
+| `security.podSecurityContext`      | Set the security context for the Ambassador pod                                 | `{ "runAsUser": "8888" }`        |
+| `security.containerSecurityContext`| Set the security context for the Ambassador container                           | `{ "allowPrivilegeEscalation": false }` |
+| `security.podSecurityPolicy`       | Create a PodSecurityPolicy to be used for the pod.                              | `[]`                              |
 | `restartPolicy`                    | Set the `restartPolicy` for pods                                                | ``                                |
 | `initContainers`                   | Containers used to initialize context for pods                                  | `[]`                              |
 | `sidecarContainers`                | Containers that share the pod context                                           | `[]`                              |

--- a/values.yaml
+++ b/values.yaml
@@ -66,29 +66,29 @@ security:
     allowPrivilegeEscalation: false
   # A basic PodSecurityPolicy to ensure Ambassador is running with appropriate security permissions
   # https://kubernetes.io/docs/concepts/policy/pod-security-policy/
-  podSecurityPolicy:
-    # Add AppArmor and Seccomp annotations
-    # https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
-    annotations:
-    spec:
-      seLinux:
-        rule: RunAsAny
-      supplementalGroups:
-        rule: 'MustRunAs'
-        ranges:
-          # Forbid adding the root group.
-          - min: 1
-            max: 65535
-      fsGroup:
-        rule: 'MustRunAs'
-        ranges:
-          # Forbid adding the root group.
-          - min: 1
-            max: 65535
-      privileged: false
-      allowPrivilegeEscalation: false
-      runAsUser:
-        rule: MustRunAsNonRoot
+  podSecurityPolicy: []
+    # # Add AppArmor and Seccomp annotations
+    # # https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
+    # annotations:
+    # spec:
+    #   seLinux:
+    #     rule: RunAsAny
+    #   supplementalGroups:
+    #     rule: 'MustRunAs'
+    #     ranges:
+    #       # Forbid adding the root group.
+    #       - min: 1
+    #         max: 65535
+    #   fsGroup:
+    #     rule: 'MustRunAs'
+    #     ranges:
+    #       # Forbid adding the root group.
+    #       - min: 1
+    #         max: 65535
+    #   privileged: false
+    #   allowPrivilegeEscalation: false
+    #   runAsUser:
+    #     rule: MustRunAsNonRoot
 
 image:
   repository: docker.io/datawire/aes

--- a/values.yaml
+++ b/values.yaml
@@ -66,6 +66,11 @@ security:
     allowPrivilegeEscalation: false
   # A basic PodSecurityPolicy to ensure Ambassador is running with appropriate security permissions
   # https://kubernetes.io/docs/concepts/policy/pod-security-policy/
+  #
+  # A set of reasonable defaults is outlined below. This is not created by default as it should only
+  # be created by a one Release. If you want to use the PodSecurityPolicy in the chart, create it in
+  # the "master" Release and then leave it unset in all others. Set the `rbac.podSecurityPolicies` 
+  # in all non-"master" Releases.
   podSecurityPolicy: []
     # # Add AppArmor and Seccomp annotations
     # # https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor


### PR DESCRIPTION
A `PodSecurityPolicy` is a cluster-wide resource that specifies a set of rules a pod must conform to be started. 

It is good to have one but there is no reason to create a `PodSecurityPolicy` for each ambassador release. Therefore, we should have the set of reasonable defaults commented out in the chart that people can use if they choose. 