### PR TITLE
Create section for redis env vars in values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## Next Release
+
+- redisEnv for setting environment variables to control how Ambassador interacts with redis. See [redis environment](https://www.getambassador.io/docs/latest/topics/running/environment/#redis)
+
 ## v6.4.3
 
 - Upgrade Ambassador to version 1.5.2: [CHANGELOG](https://github.com/datawire/ambassador/blob/master/CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `licenseKey.createSecret`          | Set to `false` if installing mutltiple Ambassdor Edge Stacks in a namespace.    | `true`                            |
 | `licenseKey.secretName`            | Name of the secret to store Ambassador license key in.                          | ``                                |
 | `redisURL`                         | URL of redis instance not created by the release                                | `""`                              |
+| `redisEnv`                         | Set env vars that control how Ambassador interacts with redis. See [redis environment](https://www.getambassador.io/docs/latest/topics/running/environment/#redis) | `""` |
 | `redis.create`                     | Create a basic redis instance with default configurations                       | `true`                            |
 | `redis.annotations`                | Annotations for the redis service and deployment                                | `""`                              |
 | `redis.resources`                  | Resource requests for the redis instance                                        | `""`                              |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -187,10 +187,15 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
               {{- end -}}
+            {{- if .Values.redisEnv }}
+            {{ toYaml .Values.redisEnv | nindent 12 }}
+            {{- end }}
             {{- if .Values.env }}
             {{- range $key,$value := .Values.env }}
+            {{- if not (contains "REDIS" $key) }}
             - name: {{ $key | upper | quote}}
               value: {{ $value | quote}}
+            {{- end }}
             {{- end }}
             {{- end }}
           {{- with .Values.security.containerSecurityContext }}

--- a/values.yaml
+++ b/values.yaml
@@ -307,6 +307,16 @@ createDevPortalMappings: true
 #
 # URL of your redis instance. Defaults to redis instance created below.
 redisURL:
+# Ambassador has a couple of environment variables that configure how it uses redis.
+# See: https://www.getambassador.io/docs/latest/topics/running/environment/#redis
+# This is interpreted as a YAML dictionary so format is the same as setting directly in Kubernetes YAML
+redisEnv:
+# - name: REDIS_PASSWORD
+#   value: password
+#   valueFrom:
+#     secretKeyRef:
+#       name: redis-password
+#       key: password
 # Ambassador ships with a basic redis instance. Configure the deployment with the options below.
 redis:
   create: true


### PR DESCRIPTION
Users would like to set the REDIS_PASSWORD to be read from a secret. The
current way to configure env vars does not support this so we created
another section for configuring the redis env

Signed-off-by: Noah Krause <krausenoah@gmail.com>
