### PR TITLE
Add a feature flag to create the project registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v6.4.4
+
+- Feature flag for enabling or disabling the [`Project` registry](https://www.getambassador.io/docs/latest/topics/using/projects/)
+
 ## v6.4.3
 
 - Upgrade Ambassador to version 1.5.2: [CHANGELOG](https://github.com/datawire/ambassador/blob/master/CHANGELOG.md)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.5.2
 ossVersion: 1.5.2
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 6.4.3
+version: 6.4.4
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `authService.create`               | Create the `AuthService` CRD for Ambassador Edge Stack                          | `true`                            |
 | `authService.optional_configurations` | Config options for the `AuthService` CRD                                     | `""`                              |
 | `rateLimit.create`                 | Create the `RateLimit` CRD for Ambassador Edge Stack                            | `true`                            |
+| `registry.create`                  | Create the `Project` registry.                                                  | `false`                           |
 | `autoscaling.enabled`              | If true, creates Horizontal Pod Autoscaler                                      | `false`                           |
 | `autoscaling.minReplicas`           | If autoscaling enabled, this field sets minimum replica count                   | `2`                               |
 | `autoscaling.maxReplicas`           | If autoscaling enabled, this field sets maximum replica count                   | `5`                               |

--- a/templates/projects-rbac.yaml
+++ b/templates/projects-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if and .Values.rbac.create .Values.registry.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 {{- if .Values.scope.singleNamespace }}
 kind: Role

--- a/templates/projects.yaml
+++ b/templates/projects.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.registry.create }}
 ######################################################################
 # In-cluster Registry for Projects
 
@@ -332,4 +333,4 @@ metadata:
     {{- end }}
     projects.getambassador.io/ambassador_id: {{ if hasKey .Values.env "AMBASSADOR_ID" }}{{ .Values.env.AMBASSADOR_ID | quote }}{{ else }}default{{ end }}
     product: aes
-
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -358,6 +358,12 @@ authService:
 rateLimit:
   create: true
 
+# Projects are a beta feature of Ambassador that allow developers to stage and
+# deploy code with nothing more than a Github repository.
+# See: https://www.getambassador.io/docs/latest/topics/using/projects/
+registry:
+  create: false
+
 ################################################################################
 ## DEPRECATED configuration objects                                           ##
 ################################################################################


### PR DESCRIPTION
The registry is a new feature and should be enabled by a feature flag for backwards compatibility