### PR TITLE
Fixed servicemonitor.yaml formatting

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.5.2
 ossVersion: 1.5.2
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 6.4.5
+version: 6.4.4
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.5.2
 ossVersion: 1.5.2
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 6.4.4
+version: 6.4.5
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: {{ include "ambassador.name" . }}
     {{- if .Values.metrics.serviceMonitor.selector }}
-    {{ toYaml .Values.metrics.serviceMonitor.selector | indent 4 }}
+    {{- toYaml .Values.metrics.serviceMonitor.selector | nindent 4 }}
     {{- end }}
 spec:
   endpoints:


### PR DESCRIPTION
Wrong indentation caused 
```
helm.go:75: [debug] error converting YAML to JSON: yaml: line 8: mapping values are not allowed in this context
YAML parse error on api-gateway/charts/ambassador/templates/servicemonitor.yaml
```

Signed-off-by: Endre Czirbesz <endre.czirbesz@rungway.com>