### PR TITLE
registry service is now using the right selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## Next Release
+
+- BugFix: Registry service is now using the proper `app.kubernetes.io/name`
+
 ## v6.4.6
 
 - Upgrade Ambassador to version 1.5.4: [CHANGELOG](https://github.com/datawire/ambassador/blob/master/CHANGELOG.md)

--- a/templates/projects.yaml
+++ b/templates/projects.yaml
@@ -96,7 +96,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app.kubernetes.io/name: {{ include "ambassador.name" . }}-registry
+    app.kubernetes.io/name: {{ include "ambassador.fullname" . }}-registry
     app.kubernetes.io/instance: {{ .Release.Name }}
   ports:
     - port: 443


### PR DESCRIPTION
The registry service was using ambassador.name instead of ambassador.fullname making it not resolve to the right service