### PR TITLE
envRaw allows for raw yaml env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 This file documents all notable changes to Ambassador Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
-## Next Release
+## 6.4.7
 
 - BugFix: Registry service is now using the proper `app.kubernetes.io/name`
+- BugFix: Restore ability to set `REDIS` env vars in `env` instead of `redisEnv`
+- Feature: Add `envRaw` to support supplying raw yaml for environment variables. Deprecates `redisEnv`.
 
 ## v6.4.6
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `hostNetwork`                      | If `true`, uses the host network, useful for on-premise setups                  | `false`                           |
 | `dnsPolicy`                        | Dns policy, when hostNetwork set to ClusterFirstWithHostNet                     | `ClusterFirst`                    |
 | `env`                              | Any additional environment variables for ambassador pods                        | `{}`                              |
+| `envRaw`                           | Additional environment variables in raw YAML format                             | `{}`                              |
 | `image.pullPolicy`                 | Ambassador image pull policy                                                    | `IfNotPresent`                    |
 | `image.repository`                 | Ambassador image                                                                | `docker.io/datawire/aes`          |
 | `image.tag`                        | Ambassador image tag                                                            | `1.5.4`                           |
@@ -141,7 +142,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `licenseKey.createSecret`          | Set to `false` if installing mutltiple Ambassdor Edge Stacks in a namespace.    | `true`                            |
 | `licenseKey.secretName`            | Name of the secret to store Ambassador license key in.                          | ``                                |
 | `redisURL`                         | URL of redis instance not created by the release                                | `""`                              |
-| `redisEnv`                         | Set env vars that control how Ambassador interacts with redis. See [redis environment](https://www.getambassador.io/docs/latest/topics/running/environment/#redis) | `""` |
+| `redisEnv`                         | (**DEPRECATED:** Use `envRaw`) Set env vars that control how Ambassador interacts with redis. | `""`                |
 | `redis.create`                     | Create a basic redis instance with default configurations                       | `true`                            |
 | `redis.annotations`                | Annotations for the redis service and deployment                                | `""`                              |
 | `redis.resources`                  | Resource requests for the redis instance                                        | `""`                              |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -192,10 +192,13 @@ spec:
             {{- end }}
             {{- if .Values.env }}
             {{- range $key,$value := .Values.env }}
-            {{- if not (contains "REDIS" $key) }}
             - name: {{ $key | upper | quote}}
               value: {{ $value | quote}}
             {{- end }}
+            {{- end }}
+            {{- if .Values.envRaw }}
+            {{- with .Values.envRaw }}
+              {{- toYaml . | nindent 12 }}
             {{- end }}
             {{- end }}
           {{- with .Values.security.containerSecurityContext }}

--- a/values.yaml
+++ b/values.yaml
@@ -53,6 +53,20 @@ env: {}
   # labels Ambassador with an ID to allow for configuring multiple Ambassadors in a cluster
   # AMBASSADOR_ID: default
 
+# Additional container environment variable in raw YAML format
+# Uncomment or add additional environment variables for the container here.
+envRaw: {}
+# - name: REDIS_PASSWORD
+#   value: password
+#   valueFrom:
+#     secretKeyRef:
+#       name: redis-password
+#       key: password
+# - name: POD_IP
+#   valueFrom:
+#     fieldRef:
+#       fieldPath: status.podIP
+
 imagePullSecrets: []
 
 security:
@@ -309,16 +323,7 @@ createDevPortalMappings: true
 #
 # URL of your redis instance. Defaults to redis instance created below.
 redisURL:
-# Ambassador has a couple of environment variables that configure how it uses redis.
-# See: https://www.getambassador.io/docs/latest/topics/running/environment/#redis
-# This is interpreted as a YAML dictionary so format is the same as setting directly in Kubernetes YAML
-redisEnv:
-# - name: REDIS_PASSWORD
-#   value: password
-#   valueFrom:
-#     secretKeyRef:
-#       name: redis-password
-#       key: password
+
 # Ambassador ships with a basic redis instance. Configure the deployment with the options below.
 redis:
   create: true


### PR DESCRIPTION
- Fixes bug that stopped you from setting REDIS environment variables in
env

- Deprecates `redisEnv` in favor of `envRaw`

Signed-off-by: Noah Krause <krausenoah@gmail.com>
