### PR TITLE
Fix #97: Cannot specify podSecurityPolicies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 ## Next Release
 
-(no changes yet)
+- BugFix: Cannot specify podSecurityPolicies: [ambassador-chart/#97](https://github.com/datawire/ambassador-chart/issues/97)
 
 ## v6.4.8
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `securityContext`                  | Set security context for pod                                                    | `{ "runAsUser": "8888" }`         |
 | `security.podSecurityContext`      | Set the security context for the Ambassador pod                                 | `{ "runAsUser": "8888" }`        |
 | `security.containerSecurityContext`| Set the security context for the Ambassador container                           | `{ "allowPrivilegeEscalation": false }` |
-| `security.podSecurityPolicy`       | Create a PodSecurityPolicy to be used for the pod.                              | `[]`                              |
+| `security.podSecurityPolicy`       | Create a PodSecurityPolicy to be used for the pod.                              | `{}`                              |
 | `restartPolicy`                    | Set the `restartPolicy` for pods                                                | ``                                |
 | `initContainers`                   | Containers used to initialize context for pods                                  | `[]`                              |
 | `sidecarContainers`                | Containers that share the pod context                                           | `[]`                              |
@@ -229,7 +229,7 @@ security:
   # be created by a one Release. If you want to use the PodSecurityPolicy in the chart, create it in
   # the "master" Release and then leave it unset in all others. Set the `rbac.podSecurityPolicies` 
   # in all non-"master" Releases.
-  podSecurityPolicy: []
+  podSecurityPolicy: {}
     # # Add AppArmor and Seccomp annotations
     # # https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
     # annotations:

--- a/values.yaml
+++ b/values.yaml
@@ -85,7 +85,7 @@ security:
   # be created by a one Release. If you want to use the PodSecurityPolicy in the chart, create it in
   # the "master" Release and then leave it unset in all others. Set the `rbac.podSecurityPolicies` 
   # in all non-"master" Releases.
-  podSecurityPolicy: []
+  podSecurityPolicy: {}
     # # Add AppArmor and Seccomp annotations
     # # https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
     # annotations:


### PR DESCRIPTION
 If one want to use a custom `values.yaml` for their Helm chart,
the bundled `values.yaml` of the existing Helm chart will get
merged with the custom values.yaml.

Since the bundled `values.yaml` defines an array `[]` for
podsecuritypolicies, but the podsecuritypolicies.yaml template
expects a map for `annotation:` and `spec:`, it is not possible
to generate a valid Helm chart.
    
The only workaround would be to ignore/delete the bundled values.yaml
altogether.

This PR fixes this issue by using a map: `{}` as a default value for
the bundled `values.yaml`

In the second, separate commit, the `Chart.yaml` and `CHANGELOG.md` are updated to create a new release.

Fixes:
  - https://github.com/datawire/ambassador-chart/issues/97
