### PR TITLE
Do not mount the secret if we do not want a secret

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -99,7 +99,7 @@ spec:
             - key: ambassadorConfig
               path: ambassador-config.yaml
         {{- end }}
-        {{- if .Values.enableAES}}
+        {{- if and .Values.licenseKey.createSecret .Values.enableAES }}
         - name: {{ include "ambassador.fullname" . }}-edge-stack-secrets
           secret:
             {{- if .Values.licenseKey.secretName }}
@@ -228,7 +228,7 @@ spec:
               mountPath: /ambassador/ambassador-config/ambassador-config.yaml
               subPath: ambassador-config.yaml
           {{- end }}
-          {{- if .Values.enableAES }}
+          {{- if and .Values.licenseKey.createSecret .Values.enableAES }}
             - name: {{ include "ambassador.fullname" . }}-edge-stack-secrets
               mountPath: /.config/ambassador
               readOnly: true


### PR DESCRIPTION
We currently have a `.Values.licenseKey.createSecret` for switching the creation of the AES license secret. However, the Secret if mounted even if `createSecret=False`. This fixes this inconsistency.
