### PR TITLE
Fix #106 - Add annotations to license-key-secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 ## Next Release
 
-(no changes yet)
+- Feature: Allow specifying annotations for the license-key-secret: [ambassador-chart/#106](https://github.com/datawire/ambassador-chart/issues/106)
 
 ## v6.4.9
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | `licenseKey.value`                 | Ambassador Edge Stack license. Empty will install in evaluation mode.           | ``                                |
 | `licenseKey.createSecret`          | Set to `false` if installing mutltiple Ambassdor Edge Stacks in a namespace.    | `true`                            |
 | `licenseKey.secretName`            | Name of the secret to store Ambassador license key in.                          | ``                                |
+| `licenseKey.annotations`           | Annotations to attach to the license-key-secret.                                | {}                                |
 | `redisURL`                         | URL of redis instance not created by the release                                | `""`                              |
 | `redisEnv`                         | (**DEPRECATED:** Use `envRaw`) Set env vars that control how Ambassador interacts with redis. | `""`                |
 | `redis.create`                     | Create a basic redis instance with default configurations                       | `true`                            |

--- a/templates/aes-secret.yaml
+++ b/templates/aes-secret.yaml
@@ -2,6 +2,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  {{- if .Values.licenseKey.annotations }}
+  annotations:
+  {{- toYaml .Values.licenseKey.annotations | nindent 4 }}
+  {{- end }}
   {{- if .Values.licenseKey.secretName }}
   name: {{ .Values.licenseKey.secretName }}
   {{- else }}

--- a/values.yaml
+++ b/values.yaml
@@ -311,6 +311,9 @@ licenseKey:
   value:
   createSecret: true
   secretName:
+  # Annotations to attach to the license-key-secret.
+  annotations:
+    {}
 
 # The DevPortal is exposed at /docs/ endpoint in the AES container.
 # Setting this to true will automatically create routes for the DevPortal.


### PR DESCRIPTION
This adds support for setting annotations on the license-key-secret.

This is a noop change. It will only add an additional field to the `values.yaml` and the templates/aes-secret`

Fixes: #106