### PR TITLE
Namespace Override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ numbering uses [semantic versioning](http://semver.org).
 
 ## Next Release
 
+- Feature: Allow overriding the namespace for the release using the values file: 
+
 ## v6.5.3
 
 - Upgrade Ambassador to version 1.7.0: [CHANGELOG](https://github.com/datawire/ambassador/blob/master/CHANGELOG.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ numbering uses [semantic versioning](http://semver.org).
 
 ## Next Release
 
-- Feature: Allow overriding the namespace for the release using the values file: 
+- Feature: Allow overriding the namespace for the release using the values file: [ambassador-chart/#122](https://github.com/datawire/ambassador-chart/pull/122)
 
 ## v6.5.3
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The following tables lists the configurable parameters of the Ambassador chart a
 | ---------------------------------- | ------------------------------------------------------------------------------- | --------------------------------- |
 | `nameOverride`                     | Override the generated chart name. Defaults to .Chart.Name.                     |                                   |
 | `fullnameOverride`                 | Override the generated release name. Defaults to .Release.Name.                 |                                   |
+| `namespaceOverride`                | Override the generated release namespace. Defaults to .Release.Namespace.       |                                   |
 | `adminService.create`              | If `true`, create a service for Ambassador's admin UI                           | `true`                            |
 | `adminService.nodePort`            | If explicit NodePort for admin service is required                              | `true`                            |
 | `adminService.type`                | Ambassador's admin service type to be used                                      | `ClusterIP`                       |

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -21,7 +21,7 @@ With your installation of the Ambassador Edge Stack, you have created a:
 {{ end }} {{ if .Values.rateLimit.create }}
 - RateLimitService named {{include "ambassador.fullname" .}}-ratelimit
 {{ end }}
-in the {{ .Release.Namespace }} namespace.
+in the {{ include "ambassador.namespace" . }} namespace.
 
 Please ensure there is not another of these resources configured in your cluster. 
 If there is, please either remove the old resource or run 
@@ -36,22 +36,22 @@ helm upgrade {{ .Release.Name }} -n {{ .Release.Namespace }} --set authService.c
 To get the IP address of Ambassador, run the following commands:
 
 {{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace}} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "ambassador.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace}} -o jsonpath="{.items[0].status.addresses[0].address}")
+  export NODE_PORT=$(kubectl get --namespace {{ include "ambassador.namespace" .}} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "ambassador.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ include "ambassador.namespace" .}} -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
 NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-     You can watch the status of by running 'kubectl get svc -w  --namespace {{ .Release.Namespace}} {{ include "ambassador.fullname" . }}'
+     You can watch the status of by running 'kubectl get svc -w  --namespace {{ include "ambassador.namespace" .}} {{ include "ambassador.fullname" . }}'
 
   On GKE/Azure:
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace}} {{ include "ambassador.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  export SERVICE_IP=$(kubectl get svc --namespace {{ include "ambassador.namespace" .}} {{ include "ambassador.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 
   On AWS:
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace}} {{ include "ambassador.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+  export SERVICE_IP=$(kubectl get svc --namespace {{ include "ambassador.namespace" .}} {{ include "ambassador.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace}} -l "app={{ include "ambassador.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods --namespace {{ include "ambassador.namespace" .}} -l "app={{ include "ambassador.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl port-forward $POD_NAME 8080:80
 {{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -25,6 +25,17 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Create chart namespace based on override value.
+*/}}
+{{- define "ambassador.namespace" -}}
+{{- if .Values.namespaceOverride -}}
+{{- .Values.namespaceOverride -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "ambassador.chart" -}}

--- a/templates/admin-service.yaml
+++ b/templates/admin-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ambassador.fullname" . }}-admin
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     helm.sh/chart: {{ include "ambassador.chart" . }}

--- a/templates/aes-authservice.yaml
+++ b/templates/aes-authservice.yaml
@@ -4,7 +4,7 @@ apiVersion: getambassador.io/v2
 kind: AuthService
 metadata:
   name: {{ include "ambassador.fullname" . }}-auth
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/templates/aes-injector.yaml
+++ b/templates/aes-injector.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ambassador.fullname" . }}-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.fullname" . }}-injector
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -43,7 +43,7 @@ spec:
         command: [ "aes-injector" ]
         env:
         - name: AGENT_MANAGER_NAMESPACE
-          value: "{{ .Release.Namespace }}"
+          value: "{{ include "ambassador.namespace" . }}"
         - name: TRAFFIC_AGENT_IMAGE
           value: "{{ .Values.servicePreview.trafficAgent.image.repository | default .Values.image.repository }}:{{ .Values.servicePreview.trafficAgent.image.tag | default .Values.image.tag }}"
         - name: TRAFFIC_AGENT_AGENT_LISTEN_PORT
@@ -73,7 +73,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ambassador.fullname" . }}-injector
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.fullname" . }}-injector
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -98,7 +98,7 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: {{ include "ambassador.fullname" . }}-injector-tls
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.fullname" . }}-injector-tls
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -112,7 +112,7 @@ metadata:
     product: aes
 type: Opaque
 data:
-  {{ $ca := genCA (printf "%s-injector.%s.svc" (include "ambassador.fullname" .) (.Release.Namespace)) 365 -}}
+  {{ $ca := genCA (printf "%s-injector.%s.svc" (include "ambassador.fullname" .) (include "ambassador.namespace" .)) 365 -}}
   crt.pem: {{ ternary (b64enc $ca.Cert) (b64enc (trim .Values.servicePreview.trafficAgent.injector.crtPEM)) (empty .Values.servicePreview.trafficAgent.injector.crtPEM) }}
   key.pem: {{ ternary (b64enc $ca.Key) (b64enc (trim .Values.servicePreview.trafficAgent.injector.keyPEM)) (empty .Values.servicePreview.trafficAgent.injector.keyPEM) }}
 ---
@@ -136,7 +136,7 @@ webhooks:
   clientConfig:
     service:
       name: {{ include "ambassador.fullname" . }}-injector
-      namespace: {{ .Release.Namespace }}
+      namespace: {{ include "ambassador.namespace" . }}
       path: "/traffic-agent"
     caBundle: {{ ternary (b64enc $ca.Cert) (b64enc (trim .Values.servicePreview.trafficAgent.injector.crtPEM)) (empty .Values.servicePreview.trafficAgent.injector.crtPEM) }}
   failurePolicy: Ignore

--- a/templates/aes-ratelimit.yaml
+++ b/templates/aes-ratelimit.yaml
@@ -4,7 +4,7 @@ apiVersion: getambassador.io/v2
 kind: RateLimitService
 metadata:
   name: {{ include "ambassador.fullname" . }}-ratelimit
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/templates/aes-redis.yaml
+++ b/templates/aes-redis.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ambassador.fullname" . }}-redis
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.fullname" . }}-redis
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -30,7 +30,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ambassador.fullname" . }}-redis
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.fullname" . }}-redis
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/templates/aes-secret.yaml
+++ b/templates/aes-secret.yaml
@@ -12,7 +12,7 @@ metadata:
   {{- else }}
   name: {{ include "ambassador.fullname" . }}-edge-stack
   {{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
 type: Opaque
 data:
   license-key: {{- if .Values.licenseKey.value }} {{ .Values.licenseKey.value | b64enc }} {{- else }} "" {{- end }}

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: '{{ include "ambassador.fullname" . }}-file-config'
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/templates/crd-delete.yaml
+++ b/templates/crd-delete.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "ambassador.fullname" . }}-crd-cleanup
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "3"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -6,7 +6,7 @@ kind: Deployment
 {{- end }}
 metadata:
   name: {{ include "ambassador.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/templates/exporter-config.yaml
+++ b/templates/exporter-config.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: '{{ include "ambassador.fullname" . }}-exporter-config'
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/templates/hpa.yaml
+++ b/templates/hpa.yaml
@@ -3,7 +3,7 @@ apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "ambassador.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/templates/pdb.yaml
+++ b/templates/pdb.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "ambassador.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/templates/podsecuritypolicy.yaml
+++ b/templates/podsecuritypolicy.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ include "ambassador.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/templates/projects-rbac.yaml
+++ b/templates/projects-rbac.yaml
@@ -42,7 +42,7 @@ kind: ClusterRoleBinding
 {{- end }}
 metadata:
   name: {{ include "ambassador.rbacName" . }}-projects
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -64,6 +64,6 @@ roleRef:
   name: {{ include "ambassador.rbacName" . }}-projects
 subjects:
   - name: {{ include "ambassador.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "ambassador.namespace" . }}
     kind: ServiceAccount
 {{- end }}

--- a/templates/projects.yaml
+++ b/templates/projects.yaml
@@ -59,7 +59,7 @@ apiVersion: getambassador.io/v2
 kind: Mapping
 metadata:
   name: {{ include "ambassador.fullname" . }}-registry
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}-registry
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -81,7 +81,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ambassador.fullname" . }}-registry
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}-registry
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -110,7 +110,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "ambassador.fullname" . }}-registry
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -170,7 +170,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "ambassador.fullname" . }}-registry-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}-registry
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -212,7 +212,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "ambassador.fullname" . }}-registry-data
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}-registry
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -238,7 +238,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "ambassador.fullname" . }}-registry-tls
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}-registry
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -320,7 +320,7 @@ apiVersion: getambassador.io/v2
 kind: ProjectController
 metadata:
   name: {{ include "ambassador.fullname" . }}-projectcontroller
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}-projectcontroller
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -7,7 +7,7 @@ kind: ClusterRole
 {{- end }}
 metadata:
   name: {{ include "ambassador.rbacName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -88,7 +88,7 @@ kind: ClusterRoleBinding
 {{- end }}
 metadata:
   name: {{ include "ambassador.rbacName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -110,6 +110,6 @@ roleRef:
   name: {{ include "ambassador.rbacName" . }}
 subjects:
   - name: {{ include "ambassador.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "ambassador.namespace" . }}
     kind: ServiceAccount
 {{- end -}}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "ambassador.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "ambassador.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "ambassador.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app: {{ include "ambassador.name" . }}
     {{- if .Values.metrics.serviceMonitor.selector }}
@@ -21,7 +21,7 @@ spec:
       {{- end }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "ambassador.namespace" . }}
   selector:
     matchLabels:
       service: ambassador-admin

--- a/templates/traffic-agent-rbac.yaml
+++ b/templates/traffic-agent-rbac.yaml
@@ -5,7 +5,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   annotations:
     # Required because Helm creates secrets before ServiceAccount, but service-account-token depends on an existing SA.
     "helm.sh/hook": "pre-install"
@@ -27,7 +27,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   annotations:
     kubernetes.io/service-account.name: traffic-agent
 type: kubernetes.io/service-account-token
@@ -36,7 +36,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -60,7 +60,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -78,7 +78,7 @@ roleRef:
   name: {{ include "ambassador.rbacName" . }}
 subjects:
   - name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "ambassador.namespace" . }}
     kind: ServiceAccount
 {{- else }}
 ## If we install Service Preview cluster-wide, this means we can't use the 'traffic-agent' ServiceAccount
@@ -88,7 +88,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ .Values.servicePreview.trafficAgent.serviceAccountName }}
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/templates/traffic-manager.yaml
+++ b/templates/traffic-manager.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -25,7 +25,7 @@ kind: ClusterRole
 {{- end }}
 metadata:
   name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -50,7 +50,7 @@ kind: ClusterRoleBinding
 {{- end }}
 metadata:
   name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -73,13 +73,13 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Values.servicePreview.trafficManager.serviceAccountName }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "ambassador.namespace" . }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: telepresence-proxy
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: telepresence-proxy
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -150,7 +150,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: telepresence-proxy
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "ambassador.namespace" . }}
   labels:
     app.kubernetes.io/name: telepresence-proxy
     app.kubernetes.io/part-of: {{ .Release.Name }}

--- a/values.yaml
+++ b/values.yaml
@@ -9,6 +9,8 @@
 nameOverride: ""
 # Defaults to .Release.Name-.Chart.Name unless .Release.Name contains "ambassador"
 fullnameOverride: ""
+# Defaults to .Release.Namespace
+namespaceOverride: ""
 
 replicaCount: 3
 daemonSet: false


### PR DESCRIPTION
Adding a namespace helper function to allow users to override the namespace value. This is useful when Ambassador is included as a dependency of another chart, when the user wants to deploy Ambassador to a separate namespace from the rest of the release. 

My current workaround is to pass the ambassador namespace to Helm and then use overrides in the values files for the application charts, but this is proving very confusing to end users.