### PR TITLE
Feature/redis image in values yaml

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.7.0
 ossVersion: 1.7.0
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 6.5.3
+version: 6.5.4
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:

--- a/templates/aes-redis.yaml
+++ b/templates/aes-redis.yaml
@@ -58,7 +58,8 @@ spec:
     spec:
       containers:
       - name: redis
-        image: redis:5.0.1
+        image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+        imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
         resources:
         {{- toYaml .Values.redis.resources | nindent 10 }}
       restartPolicy: Always

--- a/values.yaml
+++ b/values.yaml
@@ -333,6 +333,10 @@ redisURL:
 # Ambassador ships with a basic redis instance. Configure the deployment with the options below.
 redis:
   create: true
+  image:
+    repository: redis
+    tag: 5.0.1
+    pullPolicy: IfNotPresent
   # Annotations for Ambassador Pro's redis instance.
   annotations:
     deployment:


### PR DESCRIPTION
Moving redis image repository and tag definitions to `values.yaml` instead of fixed values in `templates/aes-redis.yaml`.