### PR TITLE
Configurable test ready

### DIFF
--- a/templates/tests/test-ready.yaml
+++ b/templates/tests/test-ready.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.daemonSet }}
+{{- if and (.Values.test.enabled) (not .Values.daemonSet) }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -17,7 +17,7 @@ metadata:
 spec:
   containers:
     - name: wget
-      image: busybox
+      image: {{ .Values.test.image | default "busybox" }}
       command: ['wget']
       args:  ['{{ include "ambassador.fullname" . }}:{{ include "ambassador.servicePort" . }}/ambassador/v0/check_ready']
   restartPolicy: Never

--- a/values.yaml
+++ b/values.yaml
@@ -13,6 +13,8 @@ fullnameOverride: ""
 replicaCount: 3
 daemonSet: false
 
+# This will enable the test-ready Pod (https://github.com/datawire/ambassador-chart/blob/master/templates/tests/test-ready.yaml).
+# It will spawn a busybox container to call Ambassador's check_ready endpoint to validate it is working correctly.
 test:
   enabled: true
   image: busybox

--- a/values.yaml
+++ b/values.yaml
@@ -13,6 +13,10 @@ fullnameOverride: ""
 replicaCount: 3
 daemonSet: false
 
+test:
+  enabled: true
+  image: busybox
+
 # Enable autoscaling using HorizontalPodAutoscaler
 # daemonSet: true, autoscaling will be disabled
 autoscaling:


### PR DESCRIPTION
Fixes #121

- Test Pod image is now configurable but still defaults to busybox
- Test Pod can now we disabled if desired by the user