### PR TITLE
fix: update knative clustterrole

### DIFF
--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -37,8 +37,12 @@ rules:
     verbs: ["get", "list", "watch"]
 
   - apiGroups: [ "networking.internal.knative.dev"]
-    resources: [ "clusteringresses" ]
+    resources: [ "clusteringresses", "ingresses" ]
     verbs: ["get", "list", "watch"]
+    
+  - apiGroups: [ "networking.internal.knative.dev"]
+    resources: [ "clusteringresses/status", "ingresses/status" ]
+    verbs: ["update"]
 
   - apiGroups: [ "extensions", "networking.k8s.io" ]
     resources: [ "ingresses" ]


### PR DESCRIPTION
Currently Knative Clusterrole lacks rules that allow Ambassador to change Knative Ingress resources. This pull request changes that