### PR TITLE
1.10.0 requires access to ingressclasses

### DIFF
--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -41,7 +41,7 @@ rules:
     verbs: ["get", "list", "watch"]
 
   - apiGroups: [ "extensions", "networking.k8s.io" ]
-    resources: [ "ingresses" ]
+    resources: [ "ingresses", "ingressclasses" ]
     verbs: ["get", "list", "watch"]
 
   - apiGroups: [ "extensions", "networking.k8s.io" ]


### PR DESCRIPTION
This fixes https://github.com/datawire/ambassador/issues/3136 for the helm chart