### PR TITLE
Fix CRD cleanup hook so it actually works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ numbering uses [semantic versioning](http://semver.org).
 
 ## Next Release
 
+## v6.5.16
+
+- Bugfix: Ambassador CRD cleanup will now execute as expected.
+
 ## v6.5.15
 
 - Bugfix: Ambassador RBAC now includes permissions for IngressClasses.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.10.0
 ossVersion: 1.10.0
 description: A Helm chart for Datawire Ambassador
 name: ambassador
-version: 6.5.15
+version: 6.5.16
 icon: https://www.getambassador.io/images/logo.png
 home: https://www.getambassador.io/
 sources:
@@ -23,6 +23,4 @@ maintainers:
     email: nkrause@datawire.io
   - name: lukeshu
     email: lukeshu@datawire.io
-  - name: inercia
-    email: alvaro@datawire.io
 engine: gotpl

--- a/templates/crd-delete.yaml
+++ b/templates/crd-delete.yaml
@@ -1,13 +1,89 @@
 {{- if and .Values.crds.enabled (not .Values.crds.keep)}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ambassador.serviceAccountName" . }}-crd-delete
+  namespace: {{ include "ambassador.namespace" . }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "1"
+  labels:
+    app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.deploymentTool }}
+    app.kubernetes.io/managed-by: {{ .Values.deploymentTool }}
+    {{- else }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
+    product: aes
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ include "ambassador.rbacName" . }}-crd-delete
+  namespace: {{ include "ambassador.namespace" . }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "1"
+  labels:
+    app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.deploymentTool }}
+    app.kubernetes.io/managed-by: {{ .Values.deploymentTool }}
+    {{- else }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
+    product: aes
+rules:
+  - apiGroups: [ "apiextensions.k8s.io" ]
+    resources: [ "customresourcedefinitions" ]
+    verbs: ["get", "list", "watch", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "ambassador.rbacName" . }}-crd-delete
+  namespace: {{ include "ambassador.namespace" . }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "1"
+  labels:
+    app.kubernetes.io/name: {{ include "ambassador.name" . }}
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+    helm.sh/chart: {{ include "ambassador.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- if .Values.deploymentTool }}
+    app.kubernetes.io/managed-by: {{ .Values.deploymentTool }}
+    {{- else }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- end }}
+    product: aes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "ambassador.rbacName" . }}-crd-delete
+subjects:
+  - name: {{ include "ambassador.serviceAccountName" . }}-crd-delete
+    namespace: {{ include "ambassador.namespace" . }}
+    kind: ServiceAccount
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ include "ambassador.fullname" . }}-crd-cleanup
   namespace: {{ include "ambassador.namespace" . }}
   annotations:
-    "helm.sh/hook": pre-delete
-    "helm.sh/hook-weight": "3"
+    "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "3"
   labels:
     app.kubernetes.io/name: {{ include "ambassador.name" . }}
     app.kubernetes.io/part-of: {{ .Release.Name }}
@@ -34,15 +110,14 @@ spec:
         {{- end }}
     spec:
       {{- if .Values.rbac.create }}
-      serviceAccountName: {{ include "ambassador.serviceAccountName" . }}
+      serviceAccountName: {{ include "ambassador.serviceAccountName" . }}-crd-delete
       {{- end }}
       containers:
         - name: kubectl
-          image: "k8s.gcr.io/hyperkube:v1.12.1"
-          command:
-          - /bin/sh
-          - -c
-          - >
-              kubectl delete crds -l app.kubernetes.io/name=ambassador
+          image: "buoyantio/kubectl"
+          args:
+          - delete 
+          - crds 
+          - -l app.kubernetes.io/name=ambassador
       restartPolicy: OnFailure
 {{- end }}


### PR DESCRIPTION
The CRD cleanup hook had a couple of problems

1. The ServiceAccount it was using did not have RBAC permissions to
   delete CRDs :facepalm:

2. The `"helm.sh/hook": pre-delete` meant that the CRDs were deleted
   before the rest of the release which would cause helm to fail to
delete the AES resources since they were already removed by the hook.

3. The image the job was using was waaayyyy too big

This fixes all of this

Signed-off-by: Noah Krause <krausenoah@gmail.com>
