### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ### This repo has moved.
 
-### You can now find the chart [here](https://github.com/emissary-ingress/emissary/tree/master/charts/emissary-ingress).
+### This chart has been split into [Emissary-Ingress](https://github.com/emissary-ingress/emissary/tree/master/charts/emissary-ingress) and [Edge-Stack](https://github.com/datawire/edge-stack/tree/main/charts/edge-stack). 
+
+Edge-Stack is a superset of Emissary-Ingress API Gateway.
 
 The last chart version published out of this repo was v6.6.0.


### PR DESCRIPTION
This repository was my first contact with Edge-Stack and I was feeling confused by the new link pointing to Emissary Ingress instead. It took me a bit of Googling and reading the docs to figure things out.

I hope this quick edit helps new people who stumble upon this old version for some reason.

I came from the [Digital Ocean Starter Kit](https://github.com/digitalocean/Kubernetes-Starter-Kit-Developers) repository which linked to this old version. I'll submit a PR to them too to update the link.